### PR TITLE
use 'export type'

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,28 +1,31 @@
-export {
+export type {
     ConnectPgOptions,
 } from './connect_options.ts'
 
 export {
-    connectPg,
+    connectPg
+} from './connection.ts'
+
+export type {
     PgConn,
 } from './connection.ts'
 
-export {
+export type {
     ErrorAndNoticeFields,
 } from './message_types.ts'
 
-export {
+export type {
     PreparedStatement,
 } from './prepared_statement.ts'
 
-export {
+export type {
     CompletionInfo,
     QueryResult,
     StreamingQueryResult,
     BufferedQueryResult,
 } from './query_result.ts'
 
-export {
+export type {
     Notification,
     PgError,
     PgNotice,


### PR DESCRIPTION
Deno 1.5.0 includes a breaking change to enable the `isolatedModules` flag by default: https://github.com/denoland/deno/pull/8050

The following errors in `mod.ts` on Deno v1.5.0:
```
error: TS1205 [ERROR]: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
```

This re-exports types using `export type` to fix it.